### PR TITLE
Improve gRPC lifecycle and error handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,12 @@
 import asyncio
+import contextlib
 import logging
 from contextlib import asynccontextmanager
-from concurrent.futures import ThreadPoolExecutor
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import grpc
-from grpc import aio
+from grpc import aio as grpc_aio
 
 # Generated protobuf files
 from payment.v1 import payment_pb2_grpc
@@ -15,41 +14,46 @@ from payment_handler import PaymentServiceHandler
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("payment-service")
+
+
+class EndpointFilter(logging.Filter):
+    """Filter out noisy health check access logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - logging filter
+        return "GET /health" not in record.getMessage()
+
+
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
 # gRPC Server
-async def serve_grpc():
-    server = aio.server(ThreadPoolExecutor(max_workers=10))
-    
-    # Add payment service handler
-    payment_handler = PaymentServiceHandler()
-    payment_pb2_grpc.add_PaymentServiceServicer_to_server(payment_handler, server)
-    
-    # Add insecure port
-    listen_addr = '[::]:50051'
-    server.add_insecure_port(listen_addr)
-    
-    logger.info(f"Starting gRPC server on {listen_addr}")
+async def serve_grpc(bind: str = "[::]:50051") -> None:
+    server = grpc_aio.server(maximum_concurrent_rpcs=100)
+    payment_pb2_grpc.add_PaymentServiceServicer_to_server(PaymentServiceHandler(), server)
+    server.add_insecure_port(bind)
+
+    logger.info("Starting gRPC server on %s", bind)
     await server.start()
-    
     try:
         await server.wait_for_termination()
-    except KeyboardInterrupt:
-        logger.info("Shutting down gRPC server...")
-        await server.stop(5)
+    except asyncio.CancelledError:
+        logger.info("Cancellation received; stopping gRPC server...")
+        await server.stop(grace=5)
+        raise
+    finally:
+        # Ensure stopped even if termination returns without cancellation
+        await server.stop(grace=0)
 
 # FastAPI App
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Start gRPC server in background
     grpc_task = asyncio.create_task(serve_grpc())
-    yield
-    # Cleanup
-    grpc_task.cancel()
     try:
-        await grpc_task
-    except asyncio.CancelledError:
-        pass
+        yield
+    finally:
+        grpc_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await grpc_task
 
 app = FastAPI(
     title="Payment Service",
@@ -60,8 +64,8 @@ app = FastAPI(
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure properly for production
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/app/payment_handler.py
+++ b/app/payment_handler.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 
 import grpc
@@ -9,68 +10,65 @@ logger = logging.getLogger(__name__)
 
 class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
     def __init__(self):
-        # In-memory storage for demo
-        self.payments = {}
+        self._payments: dict[str, dict] = {}
+        self._lock = asyncio.Lock()
         logger.info("PaymentServiceHandler initialized")
 
     async def CreatePayment(self, request, context):
         """Create a new payment."""
         try:
             payment_id = str(uuid.uuid4())
-            created_at = datetime.now().isoformat()
-            
-            # Store payment data
+            created_at = datetime.now(timezone.utc).isoformat()
+
             payment_data = {
                 "payment_id": payment_id,
                 "amount": request.amount,
                 "currency": request.currency,
                 "customer_id": request.customer_id,
                 "payment_method": request.payment_method,
-                "metadata": dict(request.metadata),
+                "metadata": dict(getattr(request, "metadata", {})),
                 "status": "created",
-                "created_at": created_at
+                "created_at": created_at,
             }
-            
-            self.payments[payment_id] = payment_data
-            
-            logger.info(f"Created payment: {payment_id}")
-            
+
+            async with self._lock:
+                self._payments[payment_id] = payment_data
+
+            logger.info("Created payment %s", payment_id)
             return payment_pb2.CreatePaymentResponse(
-                payment_id=payment_id,
-                status="created",
-                created_at=created_at
+                payment_id=payment_id, status="created", created_at=created_at
             )
-            
+
         except Exception as e:
-            logger.error(f"Error creating payment: {e}")
+            logger.exception("Error creating payment")
             context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details(f"Failed to create payment: {str(e)}")
+            context.set_details(f"Failed to create payment: {e}")
             return payment_pb2.CreatePaymentResponse()
 
     async def GetPayment(self, request, context):
         """Get payment by ID."""
         try:
             payment_id = request.payment_id
-            
-            if payment_id not in self.payments:
+            async with self._lock:
+                payment = self._payments.get(payment_id)
+
+            if not payment:
                 context.set_code(grpc.StatusCode.NOT_FOUND)
                 context.set_details(f"Payment not found: {payment_id}")
                 return payment_pb2.GetPaymentResponse()
-            
-            payment = self.payments[payment_id]
-            
+
             return payment_pb2.GetPaymentResponse(
                 payment_id=payment["payment_id"],
                 amount=payment["amount"],
                 currency=payment["currency"],
                 status=payment["status"],
-                created_at=payment["created_at"]
+                created_at=payment["created_at"],
             )
-            
+
         except Exception as e:
-            logger.error(f"Error getting payment: {e}")
+            logger.exception("Error getting payment")
             context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details(f"Failed to get payment: {str(e)}")
+            context.set_details(f"Failed to get payment: {e}")
             return payment_pb2.GetPaymentResponse()
 
     async def ProcessPayment(self, request, context):
@@ -78,42 +76,38 @@ class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
         try:
             payment_id = request.payment_id
             action = request.action
-            
-            if payment_id not in self.payments:
-                context.set_code(grpc.StatusCode.NOT_FOUND)
-                context.set_details(f"Payment not found: {payment_id}")
-                return payment_pb2.ProcessPaymentResponse()
-            
-            # Update payment status based on action
+
             status_map = {
                 "capture": "captured",
-                "refund": "refunded", 
-                "cancel": "cancelled"
+                "refund": "refunded",
+                "cancel": "cancelled",
             }
-            
             new_status = status_map.get(action, "processed")
-            processed_at = datetime.now().isoformat()
-            
-            self.payments[payment_id]["status"] = new_status
-            self.payments[payment_id]["processed_at"] = processed_at
-            
-            logger.info(f"Processed payment {payment_id}: {action} -> {new_status}")
-            
+            processed_at = datetime.now(timezone.utc).isoformat()
+
+            async with self._lock:
+                payment = self._payments.get(payment_id)
+                if not payment:
+                    context.set_code(grpc.StatusCode.NOT_FOUND)
+                    context.set_details(f"Payment not found: {payment_id}")
+                    return payment_pb2.ProcessPaymentResponse()
+                payment["status"] = new_status
+                payment["processed_at"] = processed_at
+
+            logger.info("Processed payment %s: %s -> %s", payment_id, action, new_status)
             return payment_pb2.ProcessPaymentResponse(
-                payment_id=payment_id,
-                status=new_status,
-                processed_at=processed_at
+                payment_id=payment_id, status=new_status, processed_at=processed_at
             )
-            
+
         except Exception as e:
-            logger.error(f"Error processing payment: {e}")
+            logger.exception("Error processing payment")
             context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details(f"Failed to process payment: {str(e)}")
+            context.set_details(f"Failed to process payment: {e}")
             return payment_pb2.ProcessPaymentResponse()
 
     async def HealthCheck(self, request, context):
         """Health check endpoint."""
         return payment_pb2.HealthCheckResponse(
             status="healthy",
-            timestamp=datetime.now().isoformat()
+            timestamp=datetime.now(timezone.utc).isoformat(),
         )

--- a/sandbox/requestor_mock/main.py
+++ b/sandbox/requestor_mock/main.py
@@ -1,17 +1,27 @@
+import os
 import asyncio
 import logging
 from contextlib import asynccontextmanager
 
 import grpc
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel
 
-# Generated protobuf files  
 from payment.v1 import payment_pb2, payment_pb2_grpc
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("requestor-mock")
+
+
+class EndpointFilter(logging.Filter):
+    """Filter out noisy health check access logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - logging filter
+        return "GET /health" not in record.getMessage()
+
+
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
 class PaymentRequest(BaseModel):
     amount: str
@@ -19,56 +29,67 @@ class PaymentRequest(BaseModel):
     customer_id: str
     payment_method: str = "card"
 
+def grpc_to_http_status(code: grpc.StatusCode) -> int:
+    mapping = {
+        grpc.StatusCode.INVALID_ARGUMENT: status.HTTP_400_BAD_REQUEST,
+        grpc.StatusCode.NOT_FOUND: status.HTTP_404_NOT_FOUND,
+        grpc.StatusCode.ALREADY_EXISTS: status.HTTP_409_CONFLICT,
+        grpc.StatusCode.PERMISSION_DENIED: status.HTTP_403_FORBIDDEN,
+        grpc.StatusCode.UNAUTHENTICATED: status.HTTP_401_UNAUTHORIZED,
+        grpc.StatusCode.RESOURCE_EXHAUSTED: status.HTTP_429_TOO_MANY_REQUESTS,
+        grpc.StatusCode.UNAVAILABLE: status.HTTP_503_SERVICE_UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED: status.HTTP_504_GATEWAY_TIMEOUT,
+    }
+    return mapping.get(code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
 class PaymentGRPCClient:
-    def __init__(self, target: str = "payment-service:50051"):
-        self.target = target
-        self.channel = None
-        self.stub = None
-    
-    async def connect(self):
-        """Connect to payment service gRPC."""
+    def __init__(self, target: str | None = None):
+        self.target = target or os.getenv("PAYMENT_GRPC_TARGET", "payment-service:50051")
+        self.channel: grpc.aio.Channel | None = None
+        self.stub: payment_pb2_grpc.PaymentServiceStub | None = None
+
+    async def connect(self, retries: int = 5, delay: float = 1.0):
         self.channel = grpc.aio.insecure_channel(self.target)
         self.stub = payment_pb2_grpc.PaymentServiceStub(self.channel)
-        
-        # Test connection
-        try:
-            response = await self.stub.HealthCheck(payment_pb2.HealthCheckRequest())
-            logger.info(f"Connected to payment service: {response.status}")
-        except Exception as e:
-            logger.error(f"Failed to connect to payment service: {e}")
-            raise
-    
+
+        for attempt in range(1, retries + 1):
+            try:
+                await self.stub.HealthCheck(payment_pb2.HealthCheckRequest())
+                logger.info("Connected to payment service at %s", self.target)
+                return
+            except grpc.RpcError as e:
+                logger.warning("Attempt %d failed: %s (%s)", attempt, e.details(), e.code().name)
+            except Exception as e:
+                logger.warning("Attempt %d failed: %r", attempt, e)
+
+            if attempt == retries:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
+
     async def disconnect(self):
-        """Disconnect from payment service."""
         if self.channel:
             await self.channel.close()
 
-    async def create_payment(self, payment_data: PaymentRequest):
-        """Create payment via gRPC."""
-        request = payment_pb2.CreatePaymentRequest(
-            amount=payment_data.amount,
-            currency=payment_data.currency,
-            customer_id=payment_data.customer_id,
-            payment_method=payment_data.payment_method
+    async def create_payment(self, payload: PaymentRequest):
+        req = payment_pb2.CreatePaymentRequest(
+            amount=payload.amount,
+            currency=payload.currency,
+            customer_id=payload.customer_id,
+            payment_method=payload.payment_method,
         )
-        
-        response = await self.stub.CreatePayment(request)
-        return {
-            "payment_id": response.payment_id,
-            "status": response.status,
-            "created_at": response.created_at
-        }
+        resp = await self.stub.CreatePayment(req)  # type: ignore[arg-type]
+        return {"payment_id": resp.payment_id, "status": resp.status, "created_at": resp.created_at}
 
     async def get_payment(self, payment_id: str):
-        """Get payment via gRPC."""
-        request = payment_pb2.GetPaymentRequest(payment_id=payment_id)
-        response = await self.stub.GetPayment(request)
+        resp = await self.stub.GetPayment(payment_pb2.GetPaymentRequest(payment_id=payment_id))
         return {
-            "payment_id": response.payment_id,
-            "amount": response.amount,
-            "currency": response.currency,
-            "status": response.status,
-            "created_at": response.created_at
+            "payment_id": resp.payment_id,
+            "amount": resp.amount,
+            "currency": resp.currency,
+            "status": resp.status,
+            "created_at": resp.created_at,
         }
 
 # Global gRPC client
@@ -76,11 +97,11 @@ grpc_client = PaymentGRPCClient()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Startup
     await grpc_client.connect()
-    yield
-    # Shutdown
-    await grpc_client.disconnect()
+    try:
+        yield
+    finally:
+        await grpc_client.disconnect()
 
 app = FastAPI(
     title="Requestor Mock Service",
@@ -97,21 +118,17 @@ async def health_check():
 async def create_payment_rest(payment: PaymentRequest):
     """REST endpoint to create payment."""
     try:
-        result = await grpc_client.create_payment(payment)
-        return {"success": True, "data": result}
-    except Exception as e:
-        logger.error(f"Failed to create payment: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        return {"success": True, "data": await grpc_client.create_payment(payment)}
+    except grpc.RpcError as e:
+        raise HTTPException(status_code=grpc_to_http_status(e.code()), detail=e.details() or e.code().name)
 
 @app.get("/api/payments/{payment_id}")
 async def get_payment_rest(payment_id: str):
     """REST endpoint to get payment."""
     try:
-        result = await grpc_client.get_payment(payment_id)
-        return {"success": True, "data": result}
-    except Exception as e:
-        logger.error(f"Failed to get payment: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        return {"success": True, "data": await grpc_client.get_payment(payment_id)}
+    except grpc.RpcError as e:
+        raise HTTPException(status_code=grpc_to_http_status(e.code()), detail=e.details() or e.code().name)
 
 # GraphQL placeholder (basic)
 @app.post("/graphql")


### PR DESCRIPTION
## Summary
- use proper async gRPC server with graceful shutdown
- protect payment store with asyncio.Lock and UTC timestamps
- map gRPC errors to HTTP statuses in requestor mock
- suppress noisy /health access logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f2f222688324bb97ab09a25beb4b