### PR TITLE
Use Decimal for payment amounts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional, Dict
 
-from sqlalchemy import String, Text, JSON, DateTime
+from sqlalchemy import String, Text, JSON, DateTime, Numeric
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -13,7 +14,7 @@ class Payment(Base):
     __tablename__ = "payments"
 
     payment_id: Mapped[str] = mapped_column(String(36), primary_key=True)
-    amount: Mapped[str] = mapped_column(Text, nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     customer_id: Mapped[str] = mapped_column(Text, nullable=False)
     payment_method: Mapped[str] = mapped_column(Text, nullable=False)

--- a/app/payment_handler.py
+++ b/app/payment_handler.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
 import grpc
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -24,9 +25,11 @@ class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
             payment_id = str(uuid.uuid4())
             created_at = datetime.now(timezone.utc)
 
+            amount = Decimal(request.amount)
+
             payment = Payment(
                 payment_id=payment_id,
-                amount=request.amount,
+                amount=amount,
                 currency=request.currency,
                 customer_id=request.customer_id,
                 payment_method=request.payment_method,
@@ -67,7 +70,7 @@ class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
 
             return payment_pb2.GetPaymentResponse(
                 payment_id=payment.payment_id,
-                amount=payment.amount,
+                amount=str(payment.amount),
                 currency=payment.currency,
                 status=payment.status,
                 created_at=payment.created_at.isoformat(),

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS payments (
     payment_id VARCHAR(36) PRIMARY KEY,
-    amount TEXT NOT NULL,
+    amount NUMERIC(12, 2) NOT NULL,
     currency VARCHAR(3) NOT NULL,
     customer_id TEXT NOT NULL,
     payment_method TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- store payments amount as Decimal using NUMERIC column
- parse gRPC request amount to Decimal and return as string
- update DB init script for NUMERIC amount

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9310678b08324980d9445a31ebea8