### PR TITLE
Use graphql_ide parameter for GraphQLRouter

### DIFF
--- a/sandbox/requestor_mock/main.py
+++ b/sandbox/requestor_mock/main.py
@@ -176,7 +176,7 @@ async def get_payment_rest(payment_id: str):
 
 # GraphQL setup
 schema = strawberry.Schema(query=Query, mutation=Mutation)
-graphql_app = GraphQLRouter(schema, graphiql=True)
+graphql_app = GraphQLRouter(schema, graphql_ide="graphiql")
 app.include_router(graphql_app, prefix="/graphql")
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- switch requestor-mock GraphQLRouter to `graphql_ide="graphiql"`

## Testing
- `pytest`
- `python -m uvicorn sandbox.requestor_mock.main:app --port 8001 --host 0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_68b932e0052883248adae8694b1fb7ab