### PR TITLE
Fix metadata handling and ensure persistence

### DIFF
--- a/app/payment_handler.py
+++ b/app/payment_handler.py
@@ -33,7 +33,7 @@ class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
                 currency=request.currency,
                 customer_id=request.customer_id,
                 payment_method=request.payment_method,
-                metadata_=dict(getattr(request, "metadata", {})),
+                metadata_=dict(request.metadata),
                 status="created",
                 created_at=created_at,
             )

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -10,6 +10,7 @@ protobuf==6.31.1
 # Database (async)
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
+aiosqlite==0.21.0
 alembic==1.14.0
 
 # HTTP clients

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT_DIR)
+sys.path.append(os.path.join(ROOT_DIR, "app"))
+
+from models import Base, Payment
+from payment_handler import PaymentServiceHandler
+from payment.v1 import payment_pb2
+
+
+@pytest.mark.asyncio
+async def test_metadata_persistence():
+    """Metadata supplied in CreatePaymentRequest should be stored in the database."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    handler = PaymentServiceHandler(sessionmaker)
+
+    metadata = {"order_id": "ABC123", "note": "test"}
+    request = payment_pb2.CreatePaymentRequest(
+        amount="100.00",
+        currency="USD",
+        customer_id="cust123",
+        payment_method="card",
+        metadata=metadata,
+    )
+    context = MagicMock()
+
+    response = await handler.CreatePayment(request, context)
+
+    async with sessionmaker() as session:
+        payment = await session.get(Payment, response.payment_id)
+        assert payment is not None
+        assert payment.metadata_ == metadata
+
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- Use request.metadata directly when storing payment metadata
- Add async test verifying metadata saved in DB
- Include aiosqlite dependency for test database support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b936ac3dd08324905f1e12c3543466