### PR TITLE
Mount scripts dir for Postgres init and bind gRPC server to IPv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository provides a gRPC-based payment service and a sandbox requestor mo
 
 ## Docker Setup
 
+Run `docker compose` commands from the repository root so that paths resolve correctly. Before starting containers, confirm that `scripts/init-db.sql` exists; Postgres uses this file to initialize the database.
+
 The project uses `docker-compose.yml` to orchestrate services:
 
 - **payment-service** – built from `app/Dockerfile`, exposes ports 8000 (HTTP) and 50051 (gRPC), and depends on Postgres.

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ settings = get_settings()
 
 
 async def serve_grpc(
-    sessionmaker: async_sessionmaker, redis: Redis | None, bind: str = "[::]:50051"
+    sessionmaker: async_sessionmaker, redis: Redis | None, bind: str = "0.0.0.0:50051"
 ) -> None:
     server = grpc_aio.server(maximum_concurrent_rpcs=100)
     payment_pb2_grpc.add_PaymentServiceServicer_to_server(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/10-init.sql
+      - ./scripts:/docker-entrypoint-initdb.d
     networks:
       - payment-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- mount entire `scripts/` directory for Postgres initialization scripts
- document running `docker compose` from repo root and verifying `scripts/init-db.sql`
- bind gRPC server to `0.0.0.0:50051` so `grpcui` can connect

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b99043be888324b696c825be69a230