### PR TITLE
Add payment adapter scaffolding and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Payment Service
 
 An experimental payment microservice showcasing a gRPC back end with a
-REST/GraphQL gateway.  It uses FastAPI for HTTP handling, SQLAlchemy with
-PostgreSQL for persistence and optional Redis caching.  A requestor mock
-service demonstrates how other systems can consume the gRPC API through REST or
+REST/GraphQL gateway. It uses FastAPI for HTTP handling, SQLAlchemy with
+PostgreSQL for persistence and optional Redis caching. A requestor mock service
+demonstrates how other systems can consume the gRPC API through REST or
 GraphQL.
 
 ## Project Layout
@@ -16,10 +16,11 @@ GraphQL.
 │   ├── main.py              # FastAPI app and gRPC server startup
 │   ├── models.py            # SQLAlchemy models (Payment table)
 │   ├── payment_handler.py   # gRPC `PaymentService` implementation
-│   └── requirements.txt     # Python dependencies
-|   |__ adapters/            # Adapters for external payment services
-|   |__ |__ stripe/          # Stripe payment adapter
-|   |__ |__ custom/          # Custom payment adapter
+│   ├── requirements.txt     # Python dependencies
+│   └── adapters/            # Integrations with external payment processors
+│       ├── base.py          # Adapter interface
+│       ├── stripe/          # Stripe payment adapter
+│       └── custom/          # Example custom payment adapter
 ├── payment/                 # Generated protobuf packages
 ├── protos/                  # Source `.proto` definitions
 │   └── payment/v1/payment.proto
@@ -36,10 +37,53 @@ GraphQL.
 └── generate_protos.sh       # Helper to regenerate gRPC stubs
 ```
 
+## Architecture and Implementation
+
+The application entry point is `app/main.py`, which starts a FastAPI server for
+health endpoints and a gRPC server implementing `PaymentService`. Business logic
+lives in `app/payment_handler.py` and persists data using the SQLAlchemy models
+from `app/models.py`. PostgreSQL provides durable storage, while Redis is used
+as an optional caching layer.
+
+## Payment Processor Adapters
+
+To support multiple payment providers the service follows an adapter pattern.
+Adapters live under `app/adapters/` and implement the
+[`PaymentAdapter`](app/adapters/base.py) interface. Each adapter translates
+between the internal payment model and the external processor's API.
+
+### Stripe Adapter
+
+[`app/adapters/stripe`](app/adapters/stripe/__init__.py) contains a minimal
+adapter for Stripe. The class is asynchronous and returns mock responses so the
+rest of the application can be developed without contacting Stripe. Replace the
+stubbed methods with calls to the official `stripe` Python package when ready to
+integrate with the real API.
+
+```python
+from adapters.stripe import StripeAdapter
+adapter = StripeAdapter(api_key="sk_test_...")
+await adapter.create_payment(10, "USD")
+```
+
+### Custom Adapter
+
+[`app/adapters/custom`](app/adapters/custom/__init__.py) demonstrates how to
+implement an in-house processor. It follows the same interface and can be used
+as a template for future adapters.
+
+### Adding New Adapters
+
+1. Create a new subdirectory under `app/adapters/`.
+2. Implement a class deriving from `PaymentAdapter`.
+3. Provide asynchronous methods for creating, capturing, refunding and cancelling
+   payments.
+4. Wire the adapter into your application components as needed.
+
 ## gRPC API
 
 The service defines a single gRPC API in
-[`protos/payment/v1/payment.proto`](protos/payment/v1/payment.proto).  The
+[`protos/payment/v1/payment.proto`](protos/payment/v1/payment.proto). The
 `PaymentService` includes five RPCs:
 
 - `CreatePayment` – store a new payment
@@ -54,8 +98,8 @@ clients.
 ## REST and GraphQL Gateways
 
 The core service only exposes a small FastAPI layer with `/health` and root
-information, but the sandbox `requestor_mock` container demonstrates how to
-wrap the gRPC API:
+information, but the sandbox `requestor_mock` container demonstrates how to wrap
+the gRPC API:
 
 - **REST**
   - `POST /api/payments` – create a payment
@@ -67,38 +111,69 @@ wrap the gRPC API:
   - Mutation `create_payment(payload: PaymentInput!)` – create a payment
 
 These endpoints internally call the gRPC `PaymentService` using the generated
-stubs.  The mock can run alongside the service via `docker-compose`.
+stubs. The mock can run alongside the service via `docker-compose`.
 
 ## Persistence and Caching
 
 `app/main.py` configures an async SQLAlchemy engine against the `DATABASE_URL`
-and sets up an optional Redis connection via `REDIS_URL`.  The
+and sets up an optional Redis connection via `REDIS_URL`. The
 `PaymentServiceHandler` writes `Payment` objects to PostgreSQL and caches recent
-lookups in Redis for five minutes.  A startup script
+lookups in Redis for five minutes. A startup script
 [`scripts/init-db.sql`](scripts/init-db.sql) creates the required `payments`
 table when the database container initialises.
 
 ## Environment Variables
 
-`.env` stores development defaults used by the service and docker-compose.  Key
+`.env` stores development defaults used by the service and docker-compose. Key
 variables include database connection details, Redis URL, ports and feature
-flags.  `app/config.py` loads these settings via `pydantic-settings`.
+flags. `app/config.py` loads these settings via `pydantic-settings`.
 
-## Building and Running
+## Docker and Docker Compose
 
-Proto stubs are generated with `generate_protos.sh`.  The provided `Makefile`
-wraps common tasks:
+The project ships with a `docker-compose.yml` file that defines the full
+runtime stack:
 
-- `make protos` – regenerate protobuf code
-- `make build` / `make up` / `make down` – manage containers
-- `make test` – run the pytest suite
+- **payment-service** – main gRPC/HTTP server built from `app/Dockerfile`.
+- **requestor-mock** – optional REST/GraphQL gateway used for examples.
+- **postgres** – PostgreSQL 13 with an init script creating the `payments`
+  table.
+- **redis** – cache backend used by the handler for fast reads.
+- **grpcui** – web-based gRPC client (enabled via the `tools` profile).
 
-The full stack (payment service, requestor mock, PostgreSQL, Redis and grpcui)
-can be started with:
+### Building Images
+
+```bash
+make build           # or: docker-compose build --no-cache
+```
+
+### Starting the Stack
 
 ```bash
 docker-compose --profile tools up -d --build
 ```
+
+The command above launches all services including the optional grpcui. Omit the
+`--profile tools` flag to start only the core dependencies. Logs for all
+containers can be tailed with `make logs` and the stack can be stopped with
+`make down`.
+
+### Running the Service Alone
+
+To build and run only the payment-service container:
+
+```bash
+docker build -t payment-service app/
+docker run --env-file .env -p 8000:8000 -p 50051:50051 payment-service
+```
+
+## Building and Running Locally
+
+Proto stubs are generated with `generate_protos.sh`. The provided `Makefile`
+wraps common tasks:
+
+- `make protos` – regenerate protobuf code
+- `make build` / `make up` / `make down` – manage containers
+- `make test` – run the pytest suite inside a container
 
 ## Tests
 
@@ -106,5 +181,3 @@ The `tests/` directory contains unit tests that verify behaviour such as
 metadata persistence, server reflection and metadata propagation through the
 REST and GraphQL gateways.
 
-start the service with tools profile:
- - docker-compose --profile tools up -d --build

--- a/app/adapters/__init__.py
+++ b/app/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters for integrating external payment processors."""
+
+from .base import PaymentAdapter
+
+__all__ = ["PaymentAdapter"]

--- a/app/adapters/base.py
+++ b/app/adapters/base.py
@@ -1,0 +1,33 @@
+"""Base classes and interfaces for payment processor adapters."""
+
+from abc import ABC, abstractmethod
+from decimal import Decimal
+from typing import Any, Dict
+
+
+class PaymentAdapter(ABC):
+    """Abstract interface for payment processor integrations.
+
+    Concrete implementations should translate between the service's internal
+    payment model and the API of a third-party provider (e.g. Stripe).  The
+    methods are intentionally minimal and return dictionaries so adapters can
+    shape the response as needed.
+    """
+
+    @abstractmethod
+    async def create_payment(
+        self, amount: Decimal, currency: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Create a payment with the external processor."""
+
+    @abstractmethod
+    async def capture_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        """Capture or authorise a previously created payment."""
+
+    @abstractmethod
+    async def refund_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        """Refund a captured payment."""
+
+    @abstractmethod
+    async def cancel_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        """Cancel a created but not yet captured payment."""

--- a/app/adapters/custom/__init__.py
+++ b/app/adapters/custom/__init__.py
@@ -1,0 +1,36 @@
+"""Example custom payment processor adapter."""
+
+from decimal import Decimal
+from typing import Any, Dict
+
+from ..base import PaymentAdapter
+
+
+class CustomAdapter(PaymentAdapter):
+    """Simple in-house payment processor implementation.
+
+    This adapter is entirely self-contained and can be adjusted to match any
+    bespoke gateway.  It mirrors the ``PaymentAdapter`` interface and returns
+    predictable mock responses suitable for testing and local development.
+    """
+
+    async def create_payment(
+        self, amount: Decimal, currency: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {
+            "id": "custom_mock",
+            "amount": str(amount),
+            "currency": currency,
+            "status": "created",
+        }
+
+    async def capture_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "captured"}
+
+    async def refund_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "refunded"}
+
+    async def cancel_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "cancelled"}
+
+__all__ = ["CustomAdapter"]

--- a/app/adapters/stripe/__init__.py
+++ b/app/adapters/stripe/__init__.py
@@ -1,0 +1,40 @@
+"""Stripe payment processor adapter."""
+
+from decimal import Decimal
+from typing import Any, Dict
+
+from ..base import PaymentAdapter
+
+
+class StripeAdapter(PaymentAdapter):
+    """Minimal Stripe integration placeholder.
+
+    Real implementations should depend on the official ``stripe`` Python
+    package and translate method calls to ``PaymentIntent`` API operations.
+    This skeleton returns mock responses so the rest of the application can be
+    developed without contacting Stripe.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def create_payment(
+        self, amount: Decimal, currency: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return {
+            "id": "pi_mock",
+            "amount": str(amount),
+            "currency": currency,
+            "status": "created",
+        }
+
+    async def capture_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "captured"}
+
+    async def refund_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "refunded"}
+
+    async def cancel_payment(self, payment_id: str, **kwargs: Any) -> Dict[str, Any]:
+        return {"id": payment_id, "status": "cancelled"}
+
+__all__ = ["StripeAdapter"]


### PR DESCRIPTION
## Summary
- scaffold Stripe and custom payment adapters with shared interface
- expand README with adapter usage and comprehensive Docker instructions

## Testing
- `make test` *(fails: Cannot install grpcio-tools==1.74.0 and protobuf==5.28.3 because these package versions have conflicting dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68baaefaca9483249488a3234befa06f