### PR TITLE
Cache payments using adapter identifiers

### DIFF
--- a/app/payment_handler.py
+++ b/app/payment_handler.py
@@ -98,22 +98,24 @@ class PaymentServiceHandler(payment_pb2_grpc.PaymentServiceServicer):
             if self._redis is not None:
                 try:
                     await self._redis.setex(
-                        self._cache_key(payment_id),
+                        self._cache_key(external_payment_id),
                         self._CACHE_TTL,
                         json.dumps(
                             {
-                                "payment_id": payment_id,
+                                "payment_id": external_payment_id,
                                 "amount": str(amount),
                                 "currency": request.currency,
-                                "status": "created",
+                                "status": adapter_status,
                                 "created_at": created_at.isoformat(),
                             }
                         ),
                     )
                 except Exception as exc:  # pragma: no cover - cache failure
-                    logger.warning("Failed to cache payment %s: %s", payment_id, exc)
+                    logger.warning(
+                        "Failed to cache payment %s: %s", external_payment_id, exc
+                    )
 
-            logger.info("Created payment %s", payment_id)
+            logger.info("Created payment %s", external_payment_id)
             return response
 
         except Exception as e:

--- a/tests/test_list_payments.py
+++ b/tests/test_list_payments.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -20,7 +20,9 @@ async def test_list_payments_returns_all():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
-    handler = PaymentServiceHandler(sessionmaker)
+    payment_adapter = AsyncMock()
+    payment_adapter.create_payment.return_value = {"status": "created"}
+    handler = PaymentServiceHandler(sessionmaker, payment_adapter)
 
     ctx = MagicMock()
     req = payment_pb2.CreatePaymentRequest(

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -21,7 +21,9 @@ async def test_metadata_persistence():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
-    handler = PaymentServiceHandler(sessionmaker)
+    payment_adapter = AsyncMock()
+    payment_adapter.create_payment.return_value = {"status": "created"}
+    handler = PaymentServiceHandler(sessionmaker, payment_adapter)
 
     metadata = {"order_id": "ABC123", "note": "test"}
     request = payment_pb2.CreatePaymentRequest(

--- a/tests/test_payment_cache.py
+++ b/tests/test_payment_cache.py
@@ -1,0 +1,68 @@
+import json
+import os
+import sys
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT_DIR)
+sys.path.append(os.path.join(ROOT_DIR, "app"))
+
+from models import Base  # noqa: E402
+from payment_handler import PaymentServiceHandler  # noqa: E402
+from payment.v1 import payment_pb2  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_cache_uses_external_payment_id(mock_redis):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    payment_adapter = AsyncMock()
+    payment_adapter.create_payment.return_value = {
+        "id": "adapter-123",
+        "status": "authorized",
+    }
+
+    handler = PaymentServiceHandler(sessionmaker, payment_adapter, mock_redis)
+
+    request = payment_pb2.CreatePaymentRequest(
+        amount="50.00",
+        currency="USD",
+        customer_id="cust-cache",
+        payment_method="card",
+    )
+    context = MagicMock()
+
+    response = await handler.CreatePayment(request, context)
+
+    assert response.payment_id == "adapter-123"
+    assert response.status == "authorized"
+
+    mock_redis.setex.assert_awaited_once()
+    cache_args = mock_redis.setex.await_args.args
+    cache_key = handler._cache_key("adapter-123")
+
+    assert cache_args[0] == cache_key
+
+    cached_payload = json.loads(cache_args[2])
+    assert cached_payload["payment_id"] == "adapter-123"
+    assert cached_payload["status"] == "authorized"
+
+    mock_redis.get.reset_mock()
+    mock_redis.get.return_value = cache_args[2]
+
+    payment_id = "adapter-123"
+    get_response = await handler.GetPayment(
+        payment_pb2.GetPaymentRequest(payment_id=payment_id), context
+    )
+
+    mock_redis.get.assert_awaited_once_with(cache_key)
+    assert get_response.payment_id == "adapter-123"
+    assert get_response.status == "authorized"
+
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- store newly created payments in Redis using the adapter-supplied identifier and status
- adjust existing payment handler tests to work with a mock adapter and add coverage for cache lookups by external ID

## Testing
- pytest *(fails: provider selection tests expect CustomAdapter when Stripe credentials are absent because `main.settings` retains prior environment values)*
- pytest tests/test_payment_cache.py -q
- pytest tests/test_list_payments.py tests/test_metadata_persistence.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8caf245c88324a0891fa17a077ed1