### PR TITLE
Handle invalid webhook payloads

### DIFF
--- a/tests/test_adapter_contract.py
+++ b/tests/test_adapter_contract.py
@@ -220,8 +220,8 @@ class TestAdapterErrorHandling:
         """Test webhook verification with invalid JSON raises appropriate error."""
         invalid_payload = b'invalid json data'
         sig_header = 'test_signature'
-        
-        with pytest.raises(Exception):  # Should raise some form of error
+
+        with pytest.raises(WebhookError):
             await custom_adapter.webhook_verify(invalid_payload, sig_header)
     
     def test_exception_hierarchy_completeness(self):


### PR DESCRIPTION
## Summary
- add defensive signature and JSON handling to the custom webhook verifier so bad payloads raise `WebhookError`
- extend adapter tests to cover invalid payloads/signatures and keep configuration-based provider selection deterministic

## Testing
- `pytest tests/test_adapters.py tests/test_adapter_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8cfe33b588324a7af20a4cb152c34